### PR TITLE
[Feature] Remove timestamps

### DIFF
--- a/backend/app/geojson/FrameConverter.py
+++ b/backend/app/geojson/FrameConverter.py
@@ -6,5 +6,5 @@ def frame_to_geojson(frames):
     return Feature(geometry=LineString(points))
 
 
-def trajectory_ids_to_list(cursor):
+def trajectory_ids_to_json(cursor):
     return {'trajectory_ids': [row[0] for row in cursor]}

--- a/backend/app/geojson/FrameConverter.py
+++ b/backend/app/geojson/FrameConverter.py
@@ -1,26 +1,9 @@
-from datetime import datetime
-
 from geojson import Feature, LineString
 
 
 def frame_to_geojson(frames):
-    points = []
-    timestamps = []
-
-    for frame in frames:
-        points.append((frame[3], frame[4]))
-        timestamps.append(frame_id_to_timestamp(frame[1], frame[2]))
-
-    line = LineString(points)
-    properties = {'timestamps': timestamps}
-    return Feature(geometry=line, properties=properties)
-
-
-def frame_id_to_timestamp(frame_group_id, frame_id):
-    hour = frame_group_id - 1
-    minute = frame_id // 2
-    second = 0 if frame_id % 2 == 0 else 30
-    return datetime(2013, 10, 22, hour, minute, second)
+    points = [(frame[3], frame[4]) for frame in frames]
+    return Feature(geometry=LineString(points))
 
 
 def trajectory_ids_to_list(cursor):

--- a/backend/app/trajectory/service.py
+++ b/backend/app/trajectory/service.py
@@ -1,12 +1,12 @@
 from app.database.hana_connector import HanaConnection
-from app.geojson.FrameConverter import frame_to_geojson, trajectory_ids_to_list
+from app.geojson.FrameConverter import frame_to_geojson, trajectory_ids_to_json
 from app.trajectory.sql import get_trajectory_by_id_sql, get_all_trajectory_ids_sql
 
 
 def get_all_trajectory_ids():
     with HanaConnection() as connection:
         connection.execute(get_all_trajectory_ids_sql())
-        return trajectory_ids_to_list(connection.fetchall())
+        return trajectory_ids_to_json(connection.fetchall())
 
 
 def get_trajectory_by_id(trajectory_id):


### PR DESCRIPTION
Timestamps are currently being calculated on the client from the position of a sample in the geojson. To reduce the response speed / size, this PR removes the timestamp conversion again.